### PR TITLE
Added support for newer KC tags

### DIFF
--- a/src/BSP/st25dv_nfctag.cpp
+++ b/src/BSP/st25dv_nfctag.cpp
@@ -87,7 +87,8 @@ NFCTAG_StatusTypeDef BSP_NFCTAG_Init(void)
     /* Check ST25DV driver ID */
     St25Dv_i2c_Drv.ReadID(&nfctag_id);
 
-    if ((nfctag_id == I_AM_ST25DV04) || (nfctag_id == I_AM_ST25DV64)) {
+    if ((nfctag_id == I_AM_ST25DV04) || (nfctag_id == I_AM_ST25DV64) || 
+        (nfctag_id == I_AM_ST25DV04KC) || (nfctag_id == I_AM_ST25DV64KC)) {
       NfctagInitialized = 1;
       Nfctag_Drv = &St25Dv_i2c_Drv;
       Nfctag_Drv->pData = &St25Dv_i2c_ExtDrv;

--- a/src/ST25DV/st25dv.h
+++ b/src/ST25DV/st25dv.h
@@ -369,6 +369,10 @@ typedef struct {
 #define I_AM_ST25DV04                        0x24
 /** @brief ST25DV 64Kbits */
 #define I_AM_ST25DV64                        0x26
+/** @brief ST25DV 4Kbits */
+#define I_AM_ST25DV04KC                      0x50
+/** @brief ST25DV 64Kbits */
+#define I_AM_ST25DV64KC                      0x51
 
 #ifndef NULL
 #define NULL      (void *) 0


### PR DESCRIPTION
The newer ST25DV04KC and ST25DV64KC tags have a different ID