### PR TITLE
fix: support using ReadURI with SMS and GEO type

### DIFF
--- a/src/ST25DVSensor.cpp
+++ b/src/ST25DVSensor.cpp
@@ -21,6 +21,11 @@
 
 int ST25DV::begin()
 {
+  return begin(NULL, 0);
+}
+
+int ST25DV::begin(uint8_t* buffer, uint16_t bufferLength)
+{
   uint8_t nfctag_id = 0;
 
   if (!NfctagInitialized) {
@@ -39,13 +44,13 @@ int ST25DV::begin()
       return NFCTAG_ERROR;
     }
 
-    int ret = ndef.begin();
+    int ret = ndef.begin(buffer, bufferLength);
     if (ret != NDEF_OK) {
       return ret;
     }
   }
   return NFCTAG_OK;
-}
+};
 
 int ST25DV::writeURI(String protocol, String uri, String info)
 {

--- a/src/ST25DVSensor.cpp
+++ b/src/ST25DVSensor.cpp
@@ -67,15 +67,8 @@ int ST25DV::readURI(String *s)
   uint16_t ret;
   sURI_Info uri = {"", "", ""};
   sRecordInfo_t recordInfo;
-  uint8_t NDEF_Buffer[100];
 
-  // increase buffer size for bigger messages
-  ret = ndef.NDEF_ReadNDEF(NDEF_Buffer);
-  if (ret) {
-    return ret;
-  }
-
-  ret = ndef.NDEF_IdentifyBuffer(&recordInfo, NDEF_Buffer);
+  ret = ndef.NDEF_IdentifyNDEF(&recordInfo);
   if (ret) {
     return ret;
   }

--- a/src/ST25DVSensor.cpp
+++ b/src/ST25DVSensor.cpp
@@ -92,7 +92,7 @@ int ST25DV::readURI(String *s)
 /*
  * @brief Writes an unabbrieved URI
  * 
- * The NFC NDEF format uses URI identifer code 0x00
+ * The NFC NDEF format uses URI identifier code 0x00
  * to indicate a URI that is not abbreviated.
  * 
  * @param uri the uri to write

--- a/src/ST25DVSensor.cpp
+++ b/src/ST25DVSensor.cpp
@@ -24,7 +24,7 @@ int ST25DV::begin()
   return begin(NULL, 0);
 }
 
-int ST25DV::begin(uint8_t* buffer, uint16_t bufferLength)
+int ST25DV::begin(uint8_t *buffer, uint16_t bufferLength)
 {
   uint8_t nfctag_id = 0;
 
@@ -91,10 +91,10 @@ int ST25DV::readURI(String *s)
 
 /*
  * @brief Writes an unabbrieved URI
- * 
+ *
  * The NFC NDEF format uses URI identifier code 0x00
  * to indicate a URI that is not abbreviated.
- * 
+ *
  * @param uri the uri to write
  * @param info to write
  * @retval success or failure
@@ -102,7 +102,7 @@ int ST25DV::readURI(String *s)
 int ST25DV::writeUnabridgedURI(String uri, String info)
 {
   sURI_Info _URI;
-  
+
   strcpy(_URI.protocol, "");
   strcpy(_URI.URI_Message, uri.c_str());
   strcpy(_URI.Information, info.c_str());
@@ -143,7 +143,7 @@ int ST25DV::readUnabridgedURI(String *s)
 
 /*
  * @brief Writes an SMS record
- * 
+ *
  * @param phoneNumber
  * @param message
  * @param info
@@ -162,7 +162,7 @@ int ST25DV::writeSMS(String phoneNumber, String message, String info)
 
 /*
  * @brief Reads an SMS record
- * 
+ *
  * @param phoneNumber
  * @param message
  * @retval success or failure
@@ -191,7 +191,7 @@ int ST25DV::readSMS(String *phoneNumber, String *message)
 
 /*
  * @brief Writes a GEO record
- * 
+ *
  * @param latitude
  * @param longitude
  * @param info
@@ -210,7 +210,7 @@ int ST25DV::writeGEO(String latitude, String longitude, String info)
 
 /*
  * @brief Reads a GEO record
- * 
+ *
  * @param latitude
  * @param longitude
  * @retval success or failure

--- a/src/ST25DVSensor.h
+++ b/src/ST25DVSensor.h
@@ -35,6 +35,7 @@ class ST25DV {
     ST25DV(int32_t gpo, int32_t lpd, TwoWire *i2c, Stream *serial = NULL) : st25dv_io(gpo, lpd, i2c, serial), ndef(&st25dv_io) {}
 
     int begin();
+    int begin(uint8_t* buffer, uint16_t bufferLength);
     int writeURI(String protocol, String uri, String info);
     int readURI(String *s);
     NDEF *getNDEF();

--- a/src/ST25DVSensor.h
+++ b/src/ST25DVSensor.h
@@ -35,7 +35,7 @@ class ST25DV {
     ST25DV(int32_t gpo, int32_t lpd, TwoWire *i2c, Stream *serial = NULL) : st25dv_io(gpo, lpd, i2c, serial), ndef(&st25dv_io) {}
 
     int begin();
-    int begin(uint8_t* buffer, uint16_t bufferLength);
+    int begin(uint8_t *buffer, uint16_t bufferLength);
     int writeURI(String protocol, String uri, String info);
     int readURI(String *s);
     int writeUnabridgedURI(String uri, String info);

--- a/src/ST25DVSensor.h
+++ b/src/ST25DVSensor.h
@@ -38,6 +38,15 @@ class ST25DV {
     int begin(uint8_t* buffer, uint16_t bufferLength);
     int writeURI(String protocol, String uri, String info);
     int readURI(String *s);
+    int writeUnabridgedURI(String uri, String info);
+    int readUnabridgedURI(String *s);
+    int writeSMS(String phoneNumber, String message, String info);
+    int readSMS(String *phoneNumber, String *message);
+    int writeGEO(String latitude, String longitude, String info);
+    int readGEO(String *latitude, String *longitude);
+    int writeEMail(String emailAdd, String subject, String message, String info);
+    int readEMail(String *emailAdd, String *subject, String *message);
+    NDEF_TypeDef readNDEFType();
     NDEF *getNDEF();
 
   protected:

--- a/src/libNDEF/NDEF_class.h
+++ b/src/libNDEF/NDEF_class.h
@@ -58,6 +58,7 @@ class NDEF {
     NDEF(ST25DV_IO *dev);
 
     uint16_t begin();
+    uint16_t begin(uint8_t* buffer, uint16_t bufferLength);
 
     //lib_NDEF
     uint16_t NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct);
@@ -185,10 +186,12 @@ class NDEF {
     void NDEF_Read_WifiToken(struct sRecordInfo *pRecordStruct, sWifiTokenInfo *pWifiTokenStruct);
 
     //libNDEF.c
+    /** @brief This buffer is used if begin isn't called with a buffer. */
+    uint8_t NDEF_Default_Buffer[NDEF_MAX_SIZE];
     /** @brief This buffer is used to store the data sent/received by the TAG. */
-    uint8_t NDEF_Buffer [NDEF_MAX_SIZE];
+    uint8_t* NDEF_Buffer;
     /** @brief Size of the buffer used to build the NDEF messages. */
-    uint32_t NDEF_Buffer_size = NDEF_MAX_SIZE;
+    uint32_t NDEF_Buffer_size;
     /** @brief This buffer is used when it's required to prepare a record before adding it to the NDEF_Buffer. */
     uint8_t NDEF_Record_Buffer [NDEF_RECORD_MAX_SIZE];
     /** @brief Size of the buffer used when a record has to be prepared. */

--- a/src/libNDEF/NDEF_class.h
+++ b/src/libNDEF/NDEF_class.h
@@ -65,7 +65,9 @@ class NDEF {
     uint16_t NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF);
     uint16_t NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF, uint16_t bufferLength);
     uint16_t NDEF_IdentifyBuffer(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF);
+    uint16_t NDEF_ReadNDEF();
     uint16_t NDEF_ReadNDEF(uint8_t *pNDEF);
+    uint16_t NDEF_ReadNDEF(uint8_t *pNDEF, uint16_t bufferLength);
     uint16_t NDEF_WriteNDEF(uint16_t NDEF_Size, uint8_t *pNDEF);
     uint16_t NDEF_ClearNDEF(void);
     uint16_t NDEF_getNDEFSize(uint16_t *Size);

--- a/src/libNDEF/NDEF_class.h
+++ b/src/libNDEF/NDEF_class.h
@@ -60,7 +60,9 @@ class NDEF {
     uint16_t begin();
 
     //lib_NDEF
+    uint16_t NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct);
     uint16_t NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF);
+    uint16_t NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF, uint16_t bufferLength);
     uint16_t NDEF_IdentifyBuffer(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF);
     uint16_t NDEF_ReadNDEF(uint8_t *pNDEF);
     uint16_t NDEF_WriteNDEF(uint16_t NDEF_Size, uint8_t *pNDEF);
@@ -131,6 +133,7 @@ class NDEF {
 
     //lib_wrapper
     uint16_t NfcTag_ReadNDEF(uint8_t *pData);
+    uint16_t NfcTag_ReadNDEF(uint8_t *pData, uint16_t MaxLength);
     uint16_t NfcTag_WriteNDEF(uint16_t Length, uint8_t *pData);
     uint16_t NfcTag_WriteProprietary(uint16_t Length, uint8_t *pData);
     uint16_t NfcTag_GetLength(uint16_t *Length);

--- a/src/libNDEF/NDEF_class.h
+++ b/src/libNDEF/NDEF_class.h
@@ -58,7 +58,7 @@ class NDEF {
     NDEF(ST25DV_IO *dev);
 
     uint16_t begin();
-    uint16_t begin(uint8_t* buffer, uint16_t bufferLength);
+    uint16_t begin(uint8_t *buffer, uint16_t bufferLength);
 
     //lib_NDEF
     uint16_t NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct);
@@ -191,7 +191,7 @@ class NDEF {
     /** @brief This buffer is used if begin isn't called with a buffer. */
     uint8_t NDEF_Default_Buffer[NDEF_MAX_SIZE];
     /** @brief This buffer is used to store the data sent/received by the TAG. */
-    uint8_t* NDEF_Buffer;
+    uint8_t *NDEF_Buffer;
     /** @brief Size of the buffer used to build the NDEF messages. */
     uint32_t NDEF_Buffer_size;
     /** @brief This buffer is used when it's required to prepare a record before adding it to the NDEF_Buffer. */

--- a/src/libNDEF/lib_NDEF.cpp
+++ b/src/libNDEF/lib_NDEF.cpp
@@ -303,7 +303,7 @@ void NDEF::NDEF_ParseURI(sRecordInfo_t *pRecordStruct)
   } else if (!memcmp(pPayload, GEO_TYPE_STRING, strlen(GEO_TYPE_STRING))) {
     pRecordStruct->NDEF_Type = URI_GEO_TYPE;
   } else {
-    pRecordStruct->NDEF_Type = UNKNOWN_TYPE;
+    pRecordStruct->NDEF_Type = UNABRIDGED_URI_TYPE;
   }
 }
 

--- a/src/libNDEF/lib_NDEF.cpp
+++ b/src/libNDEF/lib_NDEF.cpp
@@ -417,7 +417,7 @@ uint16_t NDEF::NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF)
     pRecordStruct->PayloadOffset = SizeOfRecordHeader;
   }
 
-  pRecordStruct->PayloadBufferAdd = pNDEF;
+  pRecordStruct->PayloadBufferAdd = &pNDEF[pRecordStruct->PayloadOffset];
 
   NDEF_ParseRecordHeader(pRecordStruct);
 

--- a/src/libNDEF/lib_NDEF.cpp
+++ b/src/libNDEF/lib_NDEF.cpp
@@ -364,64 +364,7 @@ uint16_t NDEF::NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF)
   /* Read the NDEF file */
   NfcTag_ReadNDEF(pNDEF);
 
-  /* Is ID length field present */
-  if ((*pNDEF) & IL_Mask) {
-    IDLengthField = ID_LENGTH_FIELD;
-  } else {
-    IDLengthField = 0;
-  }
-
-  /* it's a SR */
-  if ((*pNDEF) & SR_Mask) {
-    /* Analyse short record layout */
-    TypeNbByte = pNDEF[1];
-    PayloadLengthField = 1;
-    if (IDLengthField == ID_LENGTH_FIELD) {
-      IDNbByte = pNDEF[3];
-    } else {
-      IDNbByte = 0;
-    }
-  } else {
-    /* Analyse normal record layout */
-    TypeNbByte = pNDEF[1];
-    PayloadLengthField = 4;
-    if (IDLengthField == ID_LENGTH_FIELD) {
-      IDNbByte = pNDEF[6];
-    } else {
-      IDNbByte = 0;
-    }
-  }
-
-  SizeOfRecordHeader = RECORD_FLAG_FIELD + TYPE_LENGTH_FIELD + PayloadLengthField + IDLengthField + TypeNbByte + IDNbByte;
-
-  /* Read record header */
-  /* it's a SR */
-  if (pNDEF[0] & SR_Mask) {
-    pRecordStruct->RecordFlags = pNDEF[0];
-    pRecordStruct->TypeLength = TypeNbByte;
-    pRecordStruct->PayloadLength = pNDEF[2];
-    pRecordStruct->IDLength = IDNbByte;
-    memcpy(pRecordStruct->Type, &pNDEF[3 + IDNbByte], TypeNbByte);
-    memcpy(pRecordStruct->ID, &pNDEF[3 + IDNbByte + TypeNbByte], IDNbByte);
-    pRecordStruct->PayloadOffset = SizeOfRecordHeader;
-  } else {
-    pRecordStruct->RecordFlags = pNDEF[0];
-    pRecordStruct->TypeLength = TypeNbByte;
-    pRecordStruct->PayloadLength = (((uint32_t)pNDEF[2]) << 24) |
-                                   (((uint32_t)pNDEF[3]) << 16) |
-                                   (((uint32_t)pNDEF[4]) << 8)
-                                   | pNDEF[5] ;
-    pRecordStruct->IDLength = IDNbByte;
-    memcpy(pRecordStruct->Type, &pNDEF[6 + IDNbByte], TypeNbByte);
-    memcpy(pRecordStruct->ID, &pNDEF[6 + IDNbByte + TypeNbByte], IDNbByte);
-    pRecordStruct->PayloadOffset = SizeOfRecordHeader;
-  }
-
-  pRecordStruct->PayloadBufferAdd = &pNDEF[pRecordStruct->PayloadOffset];
-
-  NDEF_ParseRecordHeader(pRecordStruct);
-
-  return NDEF_OK;
+  return NDEF_IdentifyBuffer(pRecordStruct, pNDEF);
 }
 
 /**

--- a/src/libNDEF/lib_NDEF.cpp
+++ b/src/libNDEF/lib_NDEF.cpp
@@ -68,7 +68,21 @@ NDEF::NDEF(ST25DV_IO *dev)
 
 uint16_t NDEF::begin()
 {
+  return begin(NULL, 0);
+}
+
+uint16_t NDEF::begin(uint8_t* buffer, uint16_t bufferLength)
+{
   int ret = NDEF_OK;
+
+  if (buffer == NULL) {
+    NDEF_Buffer = NDEF_Default_Buffer;
+    NDEF_Buffer_size = NDEF_MAX_SIZE;
+  } else {
+    // TODO should we check minimum buffer length?
+    NDEF_Buffer = buffer;
+    NDEF_Buffer_size = bufferLength;
+  }
 
   if (NfcType5_NDEFDetection() != NDEF_OK) {
     CCFileStruct.MagicNumber = NFCT5_MAGICNUMBER_E1_CCFILE;

--- a/src/libNDEF/lib_NDEF.cpp
+++ b/src/libNDEF/lib_NDEF.cpp
@@ -344,6 +344,30 @@ void NDEF::NDEF_ParseSP(sRecordInfo_t *pRecordStruct)
   * @{
   */
 
+/**
+  * @brief  This function identify the NDEF message stored in tag.
+  * @param  pRecordStruct : Structure to fill with record information.
+  * @param  pNDEF : pointer on the NDEF message data.
+  * @retval NDEF_OK : record struct filled.
+  * @retval NDEF_ERROR : record struct not updated.
+  */
+uint16_t NDEF::NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct)
+{
+  return NDEF_IdentifyNDEF(pRecordStruct, NDEF_Buffer, NDEF_Buffer_size);
+}
+
+/**
+  * @brief  This function identify the NDEF message stored in tag.
+  * @deprecated use one-arg or three-arg variant
+  * @param  pRecordStruct : Structure to fill with record information.
+  * @param  pNDEF : pointer on the NDEF message data.
+  * @retval NDEF_OK : record struct filled.
+  * @retval NDEF_ERROR : record struct not updated.
+  */
+uint16_t NDEF::NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF)
+{
+  return NDEF_IdentifyNDEF(pRecordStruct, pNDEF, NDEF_MAX_SIZE);
+}
 
 /**
   * @brief  This function identify the NDEF message stored in tag.
@@ -352,7 +376,7 @@ void NDEF::NDEF_ParseSP(sRecordInfo_t *pRecordStruct)
   * @retval NDEF_OK : record struct filled.
   * @retval NDEF_ERROR : record struct not updated.
   */
-uint16_t NDEF::NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF)
+uint16_t NDEF::NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF, uint16_t bufferLength)
 {
   uint16_t SizeOfRecordHeader, TypeNbByte, PayloadLengthField, IDLengthField, IDNbByte;
 
@@ -361,8 +385,8 @@ uint16_t NDEF::NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF)
     return NDEF_ERROR;
   }
 
-  /* Read the NDEF file */
-  NfcTag_ReadNDEF(pNDEF);
+  /* Read the NDEF file up to the max length of the record header*/
+  NfcTag_ReadNDEF(pNDEF, bufferLength);
 
   return NDEF_IdentifyBuffer(pRecordStruct, pNDEF);
 }

--- a/src/libNDEF/lib_NDEF.cpp
+++ b/src/libNDEF/lib_NDEF.cpp
@@ -71,7 +71,7 @@ uint16_t NDEF::begin()
   return begin(NULL, 0);
 }
 
-uint16_t NDEF::begin(uint8_t* buffer, uint16_t bufferLength)
+uint16_t NDEF::begin(uint8_t *buffer, uint16_t bufferLength)
 {
   int ret = NDEF_OK;
 

--- a/src/libNDEF/lib_NDEF.cpp
+++ b/src/libNDEF/lib_NDEF.cpp
@@ -407,6 +407,20 @@ uint16_t NDEF::NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF, u
 
 /**
   * @brief  This function read the NDEF content of the TAG.
+  * @retval NDEF_OK : NDEF file data retrieve and store in the buffer.
+  * @retval NDEF_ERROR : not able to read NDEF from tag.
+  * @retval NDEF_ERROR_MEMORY_INTERNAL : Cannot read tag.
+  * @retval NDEF_ERROR_NOT_FORMATED : CCFile data not supported or not present.
+  * @retval NDEF_ERROR_MEMORY_TAG : Size not compatible with memory.
+  * @retval NDEF_ERROR_LOCKED : Tag locked, cannot be read.
+  */
+uint16_t NDEF::NDEF_ReadNDEF()
+{
+  return NfcTag_ReadNDEF(NDEF_Buffer, NDEF_Buffer_size);
+}
+
+/**
+  * @brief  This function read the NDEF content of the TAG.
   * @param  pNDEF : pointer on the buffer to store NDEF data.
   * @retval NDEF_OK : NDEF file data retrieve and store in the buffer.
   * @retval NDEF_ERROR : not able to read NDEF from tag.
@@ -417,9 +431,23 @@ uint16_t NDEF::NDEF_IdentifyNDEF(sRecordInfo_t *pRecordStruct, uint8_t *pNDEF, u
   */
 uint16_t NDEF::NDEF_ReadNDEF(uint8_t *pNDEF)
 {
-  return NfcTag_ReadNDEF(pNDEF);
+  return NfcTag_ReadNDEF(pNDEF, NDEF_MAX_SIZE);
 }
 
+/**
+  * @brief  This function read the NDEF content of the TAG.
+  * @param  pNDEF : pointer on the buffer to store NDEF data.
+  * @retval NDEF_OK : NDEF file data retrieve and store in the buffer.
+  * @retval NDEF_ERROR : not able to read NDEF from tag.
+  * @retval NDEF_ERROR_MEMORY_INTERNAL : Cannot read tag.
+  * @retval NDEF_ERROR_NOT_FORMATED : CCFile data not supported or not present.
+  * @retval NDEF_ERROR_MEMORY_TAG : Size not compatible with memory.
+  * @retval NDEF_ERROR_LOCKED : Tag locked, cannot be read.
+  */
+uint16_t NDEF::NDEF_ReadNDEF(uint8_t *pNDEF, uint16_t bufferLength)
+{
+  return NfcTag_ReadNDEF(pNDEF, bufferLength);
+}
 
 
 /**

--- a/src/libNDEF/lib_NDEF.h
+++ b/src/libNDEF/lib_NDEF.h
@@ -209,7 +209,7 @@
 #define URI_ID_0x23_STRING          "urn:nfc:\0"
 
 // exported variables
-extern uint8_t NDEF_Buffer[NDEF_MAX_SIZE];
+extern uint8_t* NDEF_Buffer;
 extern uint32_t NDEF_Buffer_size;
 extern uint8_t NDEF_Record_Buffer [NDEF_RECORD_MAX_SIZE];
 extern uint32_t NDEF_Record_Buffer_size;

--- a/src/libNDEF/lib_NDEF.h
+++ b/src/libNDEF/lib_NDEF.h
@@ -209,7 +209,7 @@
 #define URI_ID_0x23_STRING          "urn:nfc:\0"
 
 // exported variables
-extern uint8_t* NDEF_Buffer;
+extern uint8_t *NDEF_Buffer;
 extern uint32_t NDEF_Buffer_size;
 extern uint8_t NDEF_Record_Buffer [NDEF_RECORD_MAX_SIZE];
 extern uint32_t NDEF_Record_Buffer_size;

--- a/src/libNDEF/lib_NDEF.h
+++ b/src/libNDEF/lib_NDEF.h
@@ -217,6 +217,7 @@ extern uint32_t NDEF_Record_Buffer_size;
 typedef enum {
   UNKNOWN_TYPE = 0,
   VCARD_TYPE,
+  UNABRIDGED_URI_TYPE,
   WELL_KNOWN_ABRIDGED_URI_TYPE,
   URI_SMS_TYPE,
   URI_GEO_TYPE,

--- a/src/libNDEF/lib_NDEF_URI.cpp
+++ b/src/libNDEF/lib_NDEF_URI.cpp
@@ -283,7 +283,10 @@ uint16_t NDEF::NDEF_ReadURI(sRecordInfo_t *pRecordStruct, sURI_Info *pURI)
   uint32_t PayloadSize, RecordPosition;
   uint8_t *pData;
 
-  if (pRecordStruct->NDEF_Type == WELL_KNOWN_ABRIDGED_URI_TYPE) {
+  if (pRecordStruct->NDEF_Type == UNABRIDGED_URI_TYPE) {
+    NDEF_Parse_WellKnowType(pRecordStruct, pURI);
+    status = NDEF_OK;
+  } else if (pRecordStruct->NDEF_Type == WELL_KNOWN_ABRIDGED_URI_TYPE) {
     NDEF_Parse_WellKnowType(pRecordStruct, pURI);
     status = NDEF_OK;
   } else if (pRecordStruct->NDEF_Type == SMARTPOSTER_TYPE) {

--- a/src/libNDEF/tagtype5_wrapper.cpp
+++ b/src/libNDEF/tagtype5_wrapper.cpp
@@ -80,6 +80,19 @@
   */
 uint16_t NDEF::NfcTag_ReadNDEF(uint8_t *pData)
 {
+  return NfcTag_ReadNDEF(pData, NDEF_MAX_SIZE);
+}
+
+/**
+  * @brief  This function reads the data stored in the NDEF message.
+  * @param  pData Pointer on the buffer used to store the read data.
+  * @retval NDEF_ERROR_MEMORY_INTERNAL  The buffer is too small for the NDEF message.
+  * @retval NDEF_ERROR_NOT_FORMATED     No Capability Container detected.
+  * @retval NDEF_ERROR                  Error when reading the NDEF message.
+  * @retval NDEF_OK                     NDEF message successfully read.
+  */
+uint16_t NDEF::NfcTag_ReadNDEF(uint8_t *pData, uint16_t bufferLength)
+{
   uint16_t status = NDEF_ERROR;
   TT5_TLV_t tlv;
   uint8_t tlv_size = 0;
@@ -105,8 +118,9 @@ uint16_t NDEF::NfcTag_ReadNDEF(uint8_t *pData)
     tlv_size = 2;
     DataLength = tlv.Length;
   }
+
   /* If too many data to write return error */
-  if (DataLength > NDEF_MAX_SIZE) {
+  if (DataLength > bufferLength) {
     return NDEF_ERROR_MEMORY_INTERNAL;
   }
 


### PR DESCRIPTION
If you write a GEO or SMS URI with the `WriteURI` function, for example:

```
st25dv.writeURI("", "sms:+17035946155", "")
```

It will fail when using `ReadURI` because `NDEF_ParseURI` has special logic for looking at the URI string and changing the NDEF_Type.  For symmetry in the API and to make `ReadURI` more versatile I have added support to read the SMS and GEO types with ReadURI.